### PR TITLE
[COOK-4434] writing a timestamp: not convergent

### DIFF
--- a/templates/default/motd.tail.erb
+++ b/templates/default/motd.tail.erb
@@ -7,7 +7,6 @@ Chef Server: <%= Chef::Config[:chef_server_url] %>
 <% if node.chef_environment != '_default' -%>
 Environment: <%= node.chef_environment %>
 <% end -%>
-Last Run: <%= ::Time.now %>
 
 Roles:
 <% node['roles'].each do |role| -%>


### PR DESCRIPTION
[Ticket COOK-4434](https://tickets.opscode.com/browse/COOK-4434)

Every time Chef runs, it will update the template. This is totally idempotent, however it is not convergent. In a world where report handlers will track the number of resources updated in a Chef run, and potentially the timestamp of that run (depending on implmentation), having the last run's time stamp in the motd is less useful.
