### PR TITLE
Use correct cookbook name.

### DIFF
--- a/libraries/provider_motd_tail.rb
+++ b/libraries/provider_motd_tail.rb
@@ -33,7 +33,7 @@ class Chef::Provider::MotdTail < Chef::Provider::LWRPBase
       template new_resource.path do
         if new_resource.template_source.nil?
           source 'motd.tail.erb'
-          cookbook 'motd'
+          cookbook 'motd-tail'
         else
           source new_resource.template_source
         end


### PR DESCRIPTION
The cookbook could not be installed, as it was expecting the "motd" cookbook as dependency.

Oops, duplicate with #7 
