### PR TITLE
Show policy group/name when using policyfiles

### DIFF
--- a/templates/default/motd.tail.erb
+++ b/templates/default/motd.tail.erb
@@ -4,6 +4,10 @@ Hostname: <%= node['cloud'] ? node['cloud']['public_hostname'] : node['fqdn'] %>
 <% if ! Chef::Config[:solo] -%>
 Chef Server: <%= Chef::Config[:chef_server_url] %>
 <% end -%>
+<% if Chef::Config[:use_policyfile] -%>
+Policy Group: <%= node.policy_group %>
+Policy Name: <%= node.policy_name %>
+<% else -%>
 <% if node.chef_environment != '_default' -%>
 Environment: <%= node.chef_environment %>
 <% end -%>
@@ -11,6 +15,7 @@ Environment: <%= node.chef_environment %>
 Roles:
 <% node['roles'].each do |role| -%>
   <%= role %>
+<% end -%>
 <% end -%>
 <% if node['tags'] && !node['tags'].empty? -%>
 


### PR DESCRIPTION
This changes the output when policyfiles are in use to show the policy group and name instead of the chef environment and roles in the motd. When policyfiles aren't in use, the existing motd remains unchanged.

Signed-off-by: Mark Harrison <mark@mivok.net>