### PR TITLE
Fix deprecation warning, and fix chef registering a changed resource on every run

### DIFF
--- a/libraries/provider_motd_tail.rb
+++ b/libraries/provider_motd_tail.rb
@@ -27,20 +27,18 @@ class Chef::Provider::MotdTail < Chef::Provider::LWRPBase
   end
 
   action :create do
-    converge_by 'write the template' do
-      template new_resource.path do
-        if new_resource.template_source.nil?
-          source 'motd.tail.erb'
-          cookbook 'motd-tail'
-        else
-          source new_resource.template_source
-        end
-        owner 'root'
-        group 'root'
-        mode '0644'
-        backup 0
-        action :create
+    template new_resource.path do
+      if new_resource.template_source.nil?
+        source 'motd.tail.erb'
+        cookbook 'motd-tail'
+      else
+        source new_resource.template_source
       end
+      owner 'root'
+      group 'root'
+      mode '0644'
+      backup 0
+      action :create
     end
   end
 

--- a/libraries/resource_motd_tail.rb
+++ b/libraries/resource_motd_tail.rb
@@ -24,6 +24,6 @@ class Chef::Resource::MotdTail < Chef::Resource::LWRPBase
 
   actions :create, :delete
   default_action :create
-  attribute :path, kind_of: String, name_attribute: true, default: '/etc/motd.tail'
+  attribute :path, kind_of: String, name_attribute: true
   attribute :template_source, kind_of: String, default: nil
 end


### PR DESCRIPTION
### Description

Two fixes:

* Fix a deprecation warning
* Remove converge_by from the provider code, which if left in causes chef to mark the resource as changed on every run.