### PR TITLE
changed name of update-motd.d script, script is not run with undersco…

### DIFF
--- a/resources/motd_tail.rb
+++ b/resources/motd_tail.rb
@@ -43,7 +43,7 @@ action :create do
   if node['platform_version'].to_f > 12.04
     package 'update-motd'
 
-    template '/etc/update-motd.d/99-chef_info' do
+    template '/etc/update-motd.d/99-chef-info' do
       source '99-chef_info.erb'
       cookbook 'motd-tail'
       mode '0755'


### PR DESCRIPTION
…re in name on canonical 14.04 and 16.04 default images

### Description

The 99-chef_info script is not executed with an underscore in the script name, changing this to 99-chef-info fixes this problem and matches the style of other scripts in /etc/update-motd.d on Ubuntu 14.04 and 16.04.

No new functionality or tests just a file name change.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
