### PR TITLE
Added template cookbook property, updated readme and spec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Updates motd.tail with Chef Roles
 ]
 ```
 
+```
+motd_tail '/etc/motd.tail' do
+  action :create
+  template_source   'motd.custom.erb'
+  template_cookbook 'custom.cookbook.name'
+end
+```
+
 ### default
 
 Updates motd.tail with useful node data

--- a/resources/motd_tail.rb
+++ b/resources/motd_tail.rb
@@ -24,15 +24,15 @@ provides :motd_tail
 
 property :path, String, name_attribute: true
 property :template_source, String
+property :template_cookbook, String
 
 action :create do
+  new_resource.template_source   ||= 'motd.tail.erb'
+  new_resource.template_cookbook ||= 'motd-tail'
+
   template new_resource.path do
-    if new_resource.template_source.nil?
-      source 'motd.tail.erb'
-      cookbook 'motd-tail'
-    else
-      source new_resource.template_source
-    end
+    source new_resource.template_source
+    cookbook new_resource.template_cookbook
     mode '0644'
     owner 'root'
     group 'root'

--- a/spec/unit/motd-tail_test_spec.rb
+++ b/spec/unit/motd-tail_test_spec.rb
@@ -32,4 +32,19 @@ describe 'motd-tail_test::default' do
       mode: '0644'
     )
   end
+
+  it 'creates an motd for bob' do
+    expect(chef_run).to create_motd_tail('/etc/motd.tail.bob').with(
+      template_source:   'motd.tail.bob.erb',
+      template_cookbook: 'motd-custom'
+    )
+  end
+
+  it 'steps into motd_tail for bob' do
+    expect(chef_run).to create_template('/etc/motd.tail.bob').with(
+      owner: 'root',
+      group: 'root',
+      mode: '0644'
+    )
+  end
 end

--- a/test/fixtures/cookbooks/motd-tail_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/motd-tail_test/recipes/default.rb
@@ -8,3 +8,9 @@ motd_tail '/etc/motd.tail.noah' do
   action :create
   template_source 'motd.tail.noah.erb'
 end
+
+motd_tail '/etc/motd.tail.bob' do
+  action :create
+  template_source   'motd.tail.bob.erb'
+  template_cookbook 'motd-custom'
+end


### PR DESCRIPTION
Signed-off-by: Dustin Lactin <dustin.lactin@gmail.com>

### Description

Added the template_cookbook parameter to the motd custom resource. Updated readme and added spec tests for new functionality.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
